### PR TITLE
Update audio_platform_info.xml

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -27,7 +27,7 @@
 <audio_platform_info>
 	<acdb_ids>
 		<device name="SND_DEVICE_IN_CAMCORDER_MIC" acdb_id="34" />
-		<device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="41" />
+		<device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="4" />
 		<device name="SND_DEVICE_IN_VOICE_REC_DMIC_STEREO" acdb_id="35" />
 		<device name="SND_DEVICE_IN_VOICE_REC_MIC" acdb_id="119" />
 		<device name="SND_DEVICE_IN_VOICE_SPEAKER_DMIC" acdb_id="42" />


### PR DESCRIPTION
Edit from <device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="41" />  
To <device name="SND_DEVICE_IN_HANDSET_MIC" acdb_id="4" />
Raising up to 40 make mic does not work in apps. (Messenger, WhatsApp) . I tested in on value 4 and works well.