### PR TITLE
system.prop: Remove redundant wrong properties

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -513,6 +513,7 @@ service time_daemon /system/bin/time_daemon
     class late_start
     user root
     group root
+    disabled
 
 on property:vold.decrypt=trigger_restart_framework
     start config_bdaddr

--- a/system.prop
+++ b/system.prop
@@ -114,6 +114,7 @@ ro.sys.sdcardfs=true
 # Time services
 persist.timed.enable=true
 persist.delta_time.enable=true
+debug.time_services.enable=true
 
 # Wifi
 wifi.interface=wlan0

--- a/system.prop
+++ b/system.prop
@@ -2,11 +2,6 @@
 # system.prop for OnePlus X
 #
 
-ro.build.product=OnePlus
-ro.product.device=OnePlus
-ro.build.description=OnePlus
-ro.build.fingerprint=OnePlus/OnePlus/OnePlus:5.1.1/LMY47V/1441677661:user/release-keys
-
 # RIL
 DEVICE_PROVISIONED=1
 persist.data.netmgrd.qos.enable=true

--- a/system.prop
+++ b/system.prop
@@ -113,6 +113,7 @@ ro.sys.sdcardfs=true
 
 # Time services
 persist.timed.enable=true
+persist.delta_time.enable=true
 
 # Wifi
 wifi.interface=wlan0


### PR DESCRIPTION
Correct values get generated by the build.
These wrong ones just get in the way.

See other OnePlus device trees, such as bacon and oneplus3, for examples of system.prop without these properties.
